### PR TITLE
Improved test case for testRevertsIfTransferFromFails

### DIFF
--- a/test/unit/DSCEngineTest.t.sol
+++ b/test/unit/DSCEngineTest.t.sol
@@ -2,27 +2,22 @@
 
 pragma solidity 0.8.19;
 
-import {DeployDSC} from "../../script/DeployDSC.s.sol";
-import {DSCEngine} from "../../src/DSCEngine.sol";
-import {DecentralizedStableCoin} from "../../src/DecentralizedStableCoin.sol";
-import {HelperConfig} from "../../script/HelperConfig.s.sol";
+import { DeployDSC } from "../../script/DeployDSC.s.sol";
+import { DSCEngine } from "../../src/DSCEngine.sol";
+import { DecentralizedStableCoin } from "../../src/DecentralizedStableCoin.sol";
+import { HelperConfig } from "../../script/HelperConfig.s.sol";
 // import { ERC20Mock } from "@openzeppelin/contracts/mocks/ERC20Mock.sol"; Updated mock location
-import {ERC20Mock} from "../mocks/ERC20Mock.sol";
-import {MockV3Aggregator} from "../mocks/MockV3Aggregator.sol";
-import {MockMoreDebtDSC} from "../mocks/MockMoreDebtDSC.sol";
-import {MockFailedMintDSC} from "../mocks/MockFailedMintDSC.sol";
-import {MockFailedTransferFrom} from "../mocks/MockFailedTransferFrom.sol";
-import {MockFailedTransfer} from "../mocks/MockFailedTransfer.sol";
-import {Test, console} from "forge-std/Test.sol";
-import {StdCheats} from "forge-std/StdCheats.sol";
+import { ERC20Mock } from "../mocks/ERC20Mock.sol";
+import { MockV3Aggregator } from "../mocks/MockV3Aggregator.sol";
+import { MockMoreDebtDSC } from "../mocks/MockMoreDebtDSC.sol";
+import { MockFailedMintDSC } from "../mocks/MockFailedMintDSC.sol";
+import { MockFailedTransferFrom } from "../mocks/MockFailedTransferFrom.sol";
+import { MockFailedTransfer } from "../mocks/MockFailedTransfer.sol";
+import { Test, console } from "forge-std/Test.sol";
+import { StdCheats } from "forge-std/StdCheats.sol";
 
 contract DSCEngineTest is StdCheats, Test {
-    event CollateralRedeemed(
-        address indexed redeemFrom,
-        address indexed redeemTo,
-        address token,
-        uint256 amount
-    ); // if
+    event CollateralRedeemed(address indexed redeemFrom, address indexed redeemTo, address token, uint256 amount); // if
     // redeemFrom != redeemedTo, then it was liquidated
 
     DSCEngine public dsce;
@@ -50,13 +45,7 @@ contract DSCEngineTest is StdCheats, Test {
     function setUp() external {
         DeployDSC deployer = new DeployDSC();
         (dsc, dsce, helperConfig) = deployer.run();
-        (
-            ethUsdPriceFeed,
-            btcUsdPriceFeed,
-            weth,
-            wbtc,
-            deployerKey
-        ) = helperConfig.activeNetworkConfig();
+        (ethUsdPriceFeed, btcUsdPriceFeed, weth, wbtc, deployerKey) = helperConfig.activeNetworkConfig();
         if (block.chainid == 31_337) {
             vm.deal(user, STARTING_USER_BALANCE);
         }
@@ -88,11 +77,7 @@ contract DSCEngineTest is StdCheats, Test {
         feedAddresses.push(ethUsdPriceFeed);
         feedAddresses.push(btcUsdPriceFeed);
 
-        vm.expectRevert(
-            DSCEngine
-                .DSCEngine__TokenAddressesAndPriceFeedAddressesAmountsDontMatch
-                .selector
-        );
+        vm.expectRevert(DSCEngine.DSCEngine__TokenAddressesAndPriceFeedAddressesAmountsDontMatch.selector);
         new DSCEngine(tokenAddresses, feedAddresses, address(dsc));
     }
 
@@ -128,24 +113,14 @@ contract DSCEngineTest is StdCheats, Test {
         tokenAddresses = [address(mockWethTransferFailed)];
         feedAddresses = [ethUsdPriceFeed];
         vm.prank(owner);
-        DSCEngine mockDsce = new DSCEngine(
-            tokenAddresses,
-            feedAddresses,
-            address(dsc)
-        );
+        DSCEngine mockDsce = new DSCEngine(tokenAddresses, feedAddresses, address(dsc));
         mockWethTransferFailed.mint(user, amountCollateral);
         // Arrange - User
         vm.startPrank(user);
-        ERC20Mock(address(mockWethTransferFailed)).approve(
-            address(mockDsce),
-            amountCollateral
-        );
+        ERC20Mock(address(mockWethTransferFailed)).approve(address(mockDsce), amountCollateral);
         // Act / Assert
         vm.expectRevert(DSCEngine.DSCEngine__TransferFailed.selector);
-        mockDsce.depositCollateral(
-            address(mockWethTransferFailed),
-            amountCollateral
-        );
+        mockDsce.depositCollateral(address(mockWethTransferFailed), amountCollateral);
         vm.stopPrank();
     }
 
@@ -161,12 +136,7 @@ contract DSCEngineTest is StdCheats, Test {
     function testRevertsWithUnapprovedCollateral() public {
         ERC20Mock randToken = new ERC20Mock("RAN", "RAN", user, 100e18);
         vm.startPrank(user);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                DSCEngine.DSCEngine__TokenNotAllowed.selector,
-                address(randToken)
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(DSCEngine.DSCEngine__TokenNotAllowed.selector, address(randToken)));
         dsce.depositCollateral(address(randToken), amountCollateral);
         vm.stopPrank();
     }
@@ -179,24 +149,14 @@ contract DSCEngineTest is StdCheats, Test {
         _;
     }
 
-    function testCanDepositCollateralWithoutMinting()
-        public
-        depositedCollateral
-    {
+    function testCanDepositCollateralWithoutMinting() public depositedCollateral {
         uint256 userBalance = dsc.balanceOf(user);
         assertEq(userBalance, 0);
     }
 
-    function testCanDepositedCollateralAndGetAccountInfo()
-        public
-        depositedCollateral
-    {
-        (uint256 totalDscMinted, uint256 collateralValueInUsd) = dsce
-            .getAccountInformation(user);
-        uint256 expectedDepositedAmount = dsce.getTokenAmountFromUsd(
-            weth,
-            collateralValueInUsd
-        );
+    function testCanDepositedCollateralAndGetAccountInfo() public depositedCollateral {
+        (uint256 totalDscMinted, uint256 collateralValueInUsd) = dsce.getAccountInformation(user);
+        uint256 expectedDepositedAmount = dsce.getTokenAmountFromUsd(weth, collateralValueInUsd);
         assertEq(totalDscMinted, 0);
         assertEq(expectedDepositedAmount, amountCollateral);
     }
@@ -206,25 +166,14 @@ contract DSCEngineTest is StdCheats, Test {
     ///////////////////////////////////////
 
     function testRevertsIfMintedDscBreaksHealthFactor() public {
-        (, int256 price, , , ) = MockV3Aggregator(ethUsdPriceFeed)
-            .latestRoundData();
-        amountToMint =
-            (amountCollateral *
-                (uint256(price) * dsce.getAdditionalFeedPrecision())) /
-            dsce.getPrecision();
+        (, int256 price,,,) = MockV3Aggregator(ethUsdPriceFeed).latestRoundData();
+        amountToMint = (amountCollateral * (uint256(price) * dsce.getAdditionalFeedPrecision())) / dsce.getPrecision();
         vm.startPrank(user);
         ERC20Mock(weth).approve(address(dsce), amountCollateral);
 
-        uint256 expectedHealthFactor = dsce.calculateHealthFactor(
-            amountToMint,
-            dsce.getUsdValue(weth, amountCollateral)
-        );
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                DSCEngine.DSCEngine__BreaksHealthFactor.selector,
-                expectedHealthFactor
-            )
-        );
+        uint256 expectedHealthFactor =
+            dsce.calculateHealthFactor(amountToMint, dsce.getUsdValue(weth, amountCollateral));
+        vm.expectRevert(abi.encodeWithSelector(DSCEngine.DSCEngine__BreaksHealthFactor.selector, expectedHealthFactor));
         dsce.depositCollateralAndMintDsc(weth, amountCollateral, amountToMint);
         vm.stopPrank();
     }
@@ -237,10 +186,7 @@ contract DSCEngineTest is StdCheats, Test {
         _;
     }
 
-    function testCanMintWithDepositedCollateral()
-        public
-        depositedCollateralAndMintedDsc
-    {
+    function testCanMintWithDepositedCollateral() public depositedCollateralAndMintedDsc {
         uint256 userBalance = dsc.balanceOf(user);
         assertEq(userBalance, amountToMint);
     }
@@ -256,22 +202,14 @@ contract DSCEngineTest is StdCheats, Test {
         feedAddresses = [ethUsdPriceFeed];
         address owner = msg.sender;
         vm.prank(owner);
-        DSCEngine mockDsce = new DSCEngine(
-            tokenAddresses,
-            feedAddresses,
-            address(mockDsc)
-        );
+        DSCEngine mockDsce = new DSCEngine(tokenAddresses, feedAddresses, address(mockDsc));
         mockDsc.transferOwnership(address(mockDsce));
         // Arrange - User
         vm.startPrank(user);
         ERC20Mock(weth).approve(address(mockDsce), amountCollateral);
 
         vm.expectRevert(DSCEngine.DSCEngine__MintFailed.selector);
-        mockDsce.depositCollateralAndMintDsc(
-            weth,
-            amountCollateral,
-            amountToMint
-        );
+        mockDsce.depositCollateralAndMintDsc(weth, amountCollateral, amountToMint);
         vm.stopPrank();
     }
 
@@ -284,30 +222,16 @@ contract DSCEngineTest is StdCheats, Test {
         vm.stopPrank();
     }
 
-    function testRevertsIfMintAmountBreaksHealthFactor()
-        public
-        depositedCollateral
-    {
+    function testRevertsIfMintAmountBreaksHealthFactor() public depositedCollateral {
         // 0xe580cc6100000000000000000000000000000000000000000000000006f05b59d3b20000
         // 0xe580cc6100000000000000000000000000000000000000000000003635c9adc5dea00000
-        (, int256 price, , , ) = MockV3Aggregator(ethUsdPriceFeed)
-            .latestRoundData();
-        amountToMint =
-            (amountCollateral *
-                (uint256(price) * dsce.getAdditionalFeedPrecision())) /
-            dsce.getPrecision();
+        (, int256 price,,,) = MockV3Aggregator(ethUsdPriceFeed).latestRoundData();
+        amountToMint = (amountCollateral * (uint256(price) * dsce.getAdditionalFeedPrecision())) / dsce.getPrecision();
 
         vm.startPrank(user);
-        uint256 expectedHealthFactor = dsce.calculateHealthFactor(
-            amountToMint,
-            dsce.getUsdValue(weth, amountCollateral)
-        );
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                DSCEngine.DSCEngine__BreaksHealthFactor.selector,
-                expectedHealthFactor
-            )
-        );
+        uint256 expectedHealthFactor =
+            dsce.calculateHealthFactor(amountToMint, dsce.getUsdValue(weth, amountCollateral));
+        vm.expectRevert(abi.encodeWithSelector(DSCEngine.DSCEngine__BreaksHealthFactor.selector, expectedHealthFactor));
         dsce.mintDsc(amountToMint);
         vm.stopPrank();
     }
@@ -362,21 +286,14 @@ contract DSCEngineTest is StdCheats, Test {
         tokenAddresses = [address(mockDsc)];
         feedAddresses = [ethUsdPriceFeed];
         vm.prank(owner);
-        DSCEngine mockDsce = new DSCEngine(
-            tokenAddresses,
-            feedAddresses,
-            address(mockDsc)
-        );
+        DSCEngine mockDsce = new DSCEngine(tokenAddresses, feedAddresses, address(mockDsc));
         mockDsc.mint(user, amountCollateral);
 
         vm.prank(owner);
         mockDsc.transferOwnership(address(mockDsce));
         // Arrange - User
         vm.startPrank(user);
-        ERC20Mock(address(mockDsc)).approve(
-            address(mockDsce),
-            amountCollateral
-        );
+        ERC20Mock(address(mockDsc)).approve(address(mockDsce), amountCollateral);
         // Act / Assert
         mockDsce.depositCollateral(address(mockDsc), amountCollateral);
         vm.expectRevert(DSCEngine.DSCEngine__TransferFailed.selector);
@@ -401,10 +318,7 @@ contract DSCEngineTest is StdCheats, Test {
         vm.stopPrank();
     }
 
-    function testEmitCollateralRedeemedWithCorrectArgs()
-        public
-        depositedCollateral
-    {
+    function testEmitCollateralRedeemedWithCorrectArgs() public depositedCollateral {
         vm.expectEmit(true, true, true, true, address(dsce));
         emit CollateralRedeemed(user, user, weth, amountCollateral);
         vm.startPrank(user);
@@ -416,10 +330,7 @@ contract DSCEngineTest is StdCheats, Test {
     // redeemCollateralForDsc Tests //
     //////////////////////////////////
 
-    function testMustRedeemMoreThanZero()
-        public
-        depositedCollateralAndMintedDsc
-    {
+    function testMustRedeemMoreThanZero() public depositedCollateralAndMintedDsc {
         vm.startPrank(user);
         dsc.approve(address(dsce), amountToMint);
         vm.expectRevert(DSCEngine.DSCEngine__NeedsMoreThanZero.selector);
@@ -443,10 +354,7 @@ contract DSCEngineTest is StdCheats, Test {
     // healthFactor Tests //
     ////////////////////////
 
-    function testProperlyReportsHealthFactor()
-        public
-        depositedCollateralAndMintedDsc
-    {
+    function testProperlyReportsHealthFactor() public depositedCollateralAndMintedDsc {
         uint256 expectedHealthFactor = 100 ether;
         uint256 healthFactor = dsce.getHealthFactor(user);
         // $100 minted with $20,000 collateral at 50% liquidation threshold
@@ -456,10 +364,7 @@ contract DSCEngineTest is StdCheats, Test {
         assertEq(healthFactor, expectedHealthFactor);
     }
 
-    function testHealthFactorCanGoBelowOne()
-        public
-        depositedCollateralAndMintedDsc
-    {
+    function testHealthFactorCanGoBelowOne() public depositedCollateralAndMintedDsc {
         int256 ethUsdUpdatedPrice = 18e8; // 1 ETH = $18
         // Rememeber, we need $200 at all times if we have $100 of debt
 
@@ -483,20 +388,12 @@ contract DSCEngineTest is StdCheats, Test {
         feedAddresses = [ethUsdPriceFeed];
         address owner = msg.sender;
         vm.prank(owner);
-        DSCEngine mockDsce = new DSCEngine(
-            tokenAddresses,
-            feedAddresses,
-            address(mockDsc)
-        );
+        DSCEngine mockDsce = new DSCEngine(tokenAddresses, feedAddresses, address(mockDsc));
         mockDsc.transferOwnership(address(mockDsce));
         // Arrange - User
         vm.startPrank(user);
         ERC20Mock(weth).approve(address(mockDsce), amountCollateral);
-        mockDsce.depositCollateralAndMintDsc(
-            weth,
-            amountCollateral,
-            amountToMint
-        );
+        mockDsce.depositCollateralAndMintDsc(weth, amountCollateral, amountToMint);
         vm.stopPrank();
 
         // Arrange - Liquidator
@@ -506,11 +403,7 @@ contract DSCEngineTest is StdCheats, Test {
         vm.startPrank(liquidator);
         ERC20Mock(weth).approve(address(mockDsce), collateralToCover);
         uint256 debtToCover = 10 ether;
-        mockDsce.depositCollateralAndMintDsc(
-            weth,
-            collateralToCover,
-            amountToMint
-        );
+        mockDsce.depositCollateralAndMintDsc(weth, collateralToCover, amountToMint);
         mockDsc.approve(address(mockDsce), debtToCover);
         // Act
         int256 ethUsdUpdatedPrice = 18e8; // 1 ETH = $18
@@ -521,10 +414,7 @@ contract DSCEngineTest is StdCheats, Test {
         vm.stopPrank();
     }
 
-    function testCantLiquidateGoodHealthFactor()
-        public
-        depositedCollateralAndMintedDsc
-    {
+    function testCantLiquidateGoodHealthFactor() public depositedCollateralAndMintedDsc {
         ERC20Mock(weth).mint(liquidator, collateralToCover);
 
         vm.startPrank(liquidator);
@@ -560,9 +450,8 @@ contract DSCEngineTest is StdCheats, Test {
 
     function testLiquidationPayoutIsCorrect() public liquidated {
         uint256 liquidatorWethBalance = ERC20Mock(weth).balanceOf(liquidator);
-        uint256 expectedWeth = dsce.getTokenAmountFromUsd(weth, amountToMint) +
-            (dsce.getTokenAmountFromUsd(weth, amountToMint) /
-                dsce.getLiquidationBonus());
+        uint256 expectedWeth = dsce.getTokenAmountFromUsd(weth, amountToMint)
+            + (dsce.getTokenAmountFromUsd(weth, amountToMint) / dsce.getLiquidationBonus());
         uint256 hardCodedExpected = 6_111_111_111_111_111_110;
         assertEq(liquidatorWethBalance, hardCodedExpected);
         assertEq(liquidatorWethBalance, expectedWeth);
@@ -570,18 +459,11 @@ contract DSCEngineTest is StdCheats, Test {
 
     function testUserStillHasSomeEthAfterLiquidation() public liquidated {
         // Get how much WETH the user lost
-        uint256 amountLiquidated = dsce.getTokenAmountFromUsd(
-            weth,
-            amountToMint
-        ) +
-            (dsce.getTokenAmountFromUsd(weth, amountToMint) /
-                dsce.getLiquidationBonus());
+        uint256 amountLiquidated = dsce.getTokenAmountFromUsd(weth, amountToMint)
+            + (dsce.getTokenAmountFromUsd(weth, amountToMint) / dsce.getLiquidationBonus());
 
         uint256 usdAmountLiquidated = dsce.getUsdValue(weth, amountLiquidated);
-        uint256 expectedUserCollateralValueInUsd = dsce.getUsdValue(
-            weth,
-            amountCollateral
-        ) - (usdAmountLiquidated);
+        uint256 expectedUserCollateralValueInUsd = dsce.getUsdValue(weth, amountCollateral) - (usdAmountLiquidated);
 
         (, uint256 userCollateralValueInUsd) = dsce.getAccountInformation(user);
         uint256 hardCodedExpectedValue = 70_000_000_000_000_000_020;
@@ -590,14 +472,12 @@ contract DSCEngineTest is StdCheats, Test {
     }
 
     function testLiquidatorTakesOnUsersDebt() public liquidated {
-        (uint256 liquidatorDscMinted, ) = dsce.getAccountInformation(
-            liquidator
-        );
+        (uint256 liquidatorDscMinted,) = dsce.getAccountInformation(liquidator);
         assertEq(liquidatorDscMinted, amountToMint);
     }
 
     function testUserHasNoMoreDebt() public liquidated {
-        (uint256 userDscMinted, ) = dsce.getAccountInformation(user);
+        (uint256 userDscMinted,) = dsce.getAccountInformation(user);
         assertEq(userDscMinted, 0);
     }
 
@@ -624,15 +504,9 @@ contract DSCEngineTest is StdCheats, Test {
         assertEq(liquidationThreshold, LIQUIDATION_THRESHOLD);
     }
 
-    function testGetAccountCollateralValueFromInformation()
-        public
-        depositedCollateral
-    {
+    function testGetAccountCollateralValueFromInformation() public depositedCollateral {
         (, uint256 collateralValue) = dsce.getAccountInformation(user);
-        uint256 expectedCollateralValue = dsce.getUsdValue(
-            weth,
-            amountCollateral
-        );
+        uint256 expectedCollateralValue = dsce.getUsdValue(weth, amountCollateral);
         assertEq(collateralValue, expectedCollateralValue);
     }
 
@@ -651,10 +525,7 @@ contract DSCEngineTest is StdCheats, Test {
         dsce.depositCollateral(weth, amountCollateral);
         vm.stopPrank();
         uint256 collateralValue = dsce.getAccountCollateralValue(user);
-        uint256 expectedCollateralValue = dsce.getUsdValue(
-            weth,
-            amountCollateral
-        );
+        uint256 expectedCollateralValue = dsce.getUsdValue(weth, amountCollateral);
         assertEq(collateralValue, expectedCollateralValue);
     }
 


### PR DESCRIPTION
This PR updates the test case `testRevertsIfTransferFromFails` to improve clarity and avoid confusion regarding the endogenous vs. exogenous nature of the contracts involved.

### Changes Made:
- Renamed mock contract to `mockWethTransferFailed` for better clarity.
- Adjusted the test setup to differentiate the collateral contract from the DSC contract.

### Diff:
```diff
// Arrange - Setup
address owner = msg.sender;
vm.prank(owner);
-MockFailedTransferFrom mockDsc = new MockFailedTransferFrom();
-tokenAddresses = [address(mockDsc)];
+MockFailedTransferFrom mockWethTransferFailed = new MockFailedTransferFrom();
+tokenAddresses = [address(mockWethTransferFailed)];
feedAddresses = [ethUsdPriceFeed];
vm.prank(owner);
-DSCEngine mockDsce = new DSCEngine(tokenAddresses, feedAddresses, address(mockDsc));
-mockDsc.mint(user, amountCollateral);
+DSCEngine mockDsce = new DSCEngine(tokenAddresses, feedAddresses, address(dsc));
+mockWethTransferFailed.mint(user, amountCollateral);

// Arrange - User
vm.startPrank(user);
-ERC20Mock(address(mockDsc)).approve(address(mockDsce), amountCollateral);
+ERC20Mock(address(mockWethTransferFailed)).approve(address(mockDsce), amountCollateral);
// Act / Assert
vm.expectRevert(DSCEngine.DSCEngine__TransferFailed.selector);
-mockDsce.depositCollateral(address(mockDsc), amountCollateral);
+mockDsce.depositCollateral(address(mockWethTransferFailed), amountCollateral);
vm.stopPrank();
```

By making these changes, the test case now more clearly represents an exogenous collateral scenario, reducing potential confusion.