### PR TITLE
Update ERC20Mock import

### DIFF
--- a/test/unit/DSCEngineTest.t.sol
+++ b/test/unit/DSCEngineTest.t.sol
@@ -6,7 +6,7 @@ import { DeployDSC } from "../../script/DeployDSC.s.sol";
 import { DSCEngine } from "../../src/DSCEngine.sol";
 import { DecentralizedStableCoin } from "../../src/DecentralizedStableCoin.sol";
 import { HelperConfig } from "../../script/HelperConfig.s.sol";
-// import { ERC20Mock } from "@openzeppelin/contracts/mocks/ERC20Mock.sol"; Updated mock location
+import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol"; // The new update of import (ERC20Mock)
 import { ERC20Mock } from "../mocks/ERC20Mock.sol";
 import { MockV3Aggregator } from "../mocks/MockV3Aggregator.sol";
 import { MockMoreDebtDSC } from "../mocks/MockMoreDebtDSC.sol";


### PR DESCRIPTION
Replace the old import statement for ERC20Mock:
Old:
```solidity
import { ERC20Mock } from "@openzeppelin/contracts/mocks/ERC20Mock.sol"; // Updated mock location
```
New:
```solidity
import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
```