### PR TITLE
Update ERC20Mock import

### DIFF
--- a/test/fuzz/failOnRevert/StopOnRevertHandler.t.sol
+++ b/test/fuzz/failOnRevert/StopOnRevertHandler.t.sol
@@ -4,9 +4,8 @@ pragma solidity ^0.8.19;
 
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import { Test } from "forge-std/Test.sol";
-// import { ERC20Mock } from "@openzeppelin/contracts/mocks/ERC20Mock.sol"; Updated mock location
+import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol"; // New updated of import (ERC20Mock)
 import { ERC20Mock } from "../../mocks/ERC20Mock.sol";
-
 import { MockV3Aggregator } from "../../mocks/MockV3Aggregator.sol";
 import { DSCEngine, AggregatorV3Interface } from "../../../src/DSCEngine.sol";
 import { DecentralizedStableCoin } from "../../../src/DecentralizedStableCoin.sol";


### PR DESCRIPTION
Replace the old import statement for ERC20Mock:
Old:
```solidity
import { ERC20Mock } from "@openzeppelin/contracts/mocks/ERC20Mock.sol"; // Updated mock location
```
New:
```solidity
import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
```