### PR TITLE
Replaced assert with assertGe in "invariant_protocolMustHaveMoreValueThatTotalSupplyDollars" tests

### DIFF
--- a/test/fuzz/continueOnRevert/ContinueOnRevertInvariants.t.sol
+++ b/test/fuzz/continueOnRevert/ContinueOnRevertInvariants.t.sol
@@ -62,7 +62,7 @@ contract ContinueOnRevertInvariants is StdInvariant, Test {
         console.log("wethValue: %s", wethValue);
         console.log("wbtcValue: %s", wbtcValue);
 
-        assert(wethValue + wbtcValue >= totalSupply);
+        assertGe(wethValue + wbtcValue, totalSupply);
     }
 
     // function invariant_userCantCreateStabelcoinWithPoorHealthFactor() public {}

--- a/test/fuzz/failOnRevert/StopOnRevertInvariants.t.sol
+++ b/test/fuzz/failOnRevert/StopOnRevertInvariants.t.sol
@@ -62,7 +62,7 @@ contract StopOnRevertInvariants is StdInvariant, Test {
         console.log("wethValue: %s", wethValue);
         console.log("wbtcValue: %s", wbtcValue);
 
-        assert(wethValue + wbtcValue >= totalSupply);
+        assertGe(wethValue + wbtcValue, totalSupply);
     }
 
     function invariant_gettersCantRevert() public view {


### PR DESCRIPTION
In the latest foundry version, using `assert` in invariant tests is getting reverted with:

```bash
[FAIL. Reason: failed to set up invariant testing environment: panic: assertion failed (0x01)]
```

So, the solution would be to replace `assert` with either `assertEq`, `assertGe` or `assertLe` depending on the type of comparison while [defining invariants](https://book.getfoundry.sh/forge/invariant-testing#defining-invariants).