### PR TITLE
Modifying fuzz tests

### DIFF
--- a/test/fuzz/continueOnRevert/ContinueOnRevertInvariants.t.sol
+++ b/test/fuzz/continueOnRevert/ContinueOnRevertInvariants.t.sol
@@ -62,7 +62,7 @@ contract ContinueOnRevertInvariants is StdInvariant, Test {
         console.log("wethValue: %s", wethValue);
         console.log("wbtcValue: %s", wbtcValue);
 
-        assert(wethValue + wbtcValue >= totalSupply);
+        assert(wethValue + wbtcValue >= (totalSupply*2));
     }
 
     // function invariant_userCantCreateStabelcoinWithPoorHealthFactor() public {}

--- a/test/fuzz/failOnRevert/StopOnRevertInvariants.t.sol
+++ b/test/fuzz/failOnRevert/StopOnRevertInvariants.t.sol
@@ -62,7 +62,7 @@ contract StopOnRevertInvariants is StdInvariant, Test {
         console.log("wethValue: %s", wethValue);
         console.log("wbtcValue: %s", wbtcValue);
 
-        assert(wethValue + wbtcValue >= totalSupply);
+        assert(wethValue + wbtcValue >= (totalSupply*2));
     }
 
     function invariant_gettersCantRevert() public view {


### PR DESCRIPTION
Our stablecoin is 200% overcollateralized so in the fuzz tests we must see if the (totalSupply *2) and not totalSupply is lesser than or equal to the collateral.  

The assert for our invariant shall be as follows:
```solidity
assert(wethValue + wbtcValue >= (totalSupply*2));
```

First official PR. I hope it's not trivial / not well formatted. 