### PR TITLE
Double dsce.getLiquidationBonus();

### DIFF
--- a/test/fuzz/failOnRevert/StopOnRevertInvariants.t.sol
+++ b/test/fuzz/failOnRevert/StopOnRevertInvariants.t.sol
@@ -69,7 +69,6 @@ contract StopOnRevertInvariants is StdInvariant, Test {
         dsce.getAdditionalFeedPrecision();
         dsce.getCollateralTokens();
         dsce.getLiquidationBonus();
-        dsce.getLiquidationBonus();
         dsce.getLiquidationThreshold();
         dsce.getMinHealthFactor();
         dsce.getPrecision();


### PR DESCRIPTION
the invariant getters test function contained two instances of the dsce.getLiquidationBonus();