### PR TITLE
Fix comment errors in DSCEngine contract

### DIFF
--- a/src/DSCEngine.sol
+++ b/src/DSCEngine.sol
@@ -198,7 +198,7 @@ contract DSCEngine is ReentrancyGuard {
     }
 
     /*
-    * @param collateral: The ERC20 token address of the collateral you're using to make the protocol solvent again.
+     * @param collateral: The ERC20 token address of the collateral you're using to make the protocol solvent again.
      * This is collateral that you're going to take from the user who is insolvent.
      * In return, you have to burn your DSC to pay off their debt, but you don't pay off your own.
      * @param user: The user who is insolvent. They have to have a _healthFactor below MIN_HEALTH_FACTOR

--- a/src/DSCEngine.sol
+++ b/src/DSCEngine.sol
@@ -149,8 +149,8 @@ contract DSCEngine is ReentrancyGuard {
     }
 
     /*
-     * @param tokenCollateralAddress: The ERC20 token address of the collateral you're depositing
-     * @param amountCollateral: The amount of collateral you're depositing
+     * @param tokenCollateralAddress: The ERC20 token address of the collateral you're withdrawing
+     * @param amountCollateral: The amount of collateral you're withdrawing
      * @param amountDscToBurn: The amount of DSC you want to burn
      * @notice This function will withdraw your collateral and burn DSC in one transaction
      */
@@ -190,7 +190,7 @@ contract DSCEngine is ReentrancyGuard {
     /*
      * @notice careful! You'll burn your DSC here! Make sure you want to do this...
      * @dev you might want to use this if you're nervous you might get liquidated and want to just burn
-     * you DSC but keep your collateral in.
+     * your DSC but keep your collateral in.
      */
     function burnDsc(uint256 amount) external moreThanZero(amount) {
         _burnDsc(amount, msg.sender, msg.sender);
@@ -198,7 +198,7 @@ contract DSCEngine is ReentrancyGuard {
     }
 
     /*
-     * @param collateral: The ERC20 token address of the collateral you're using to make the protocol solvent again.
+    * @param collateral: The ERC20 token address of the collateral you're using to make the protocol solvent again.
      * This is collateral that you're going to take from the user who is insolvent.
      * In return, you have to burn your DSC to pay off their debt, but you don't pay off your own.
      * @param user: The user who is insolvent. They have to have a _healthFactor below MIN_HEALTH_FACTOR
@@ -250,7 +250,7 @@ contract DSCEngine is ReentrancyGuard {
     ///////////////////
     /*
      * @param amountDscToMint: The amount of DSC you want to mint
-     * You can only mint DSC if you hav enough collateral
+     * You can only mint DSC if you have enough collateral
      */
     function mintDsc(uint256 amountDscToMint) public moreThanZero(amountDscToMint) nonReentrant {
         s_DSCMinted[msg.sender] += amountDscToMint;


### PR DESCRIPTION
This pull request addresses several minor documentation and comment issues in the DSCEngine contract:

1. Corrected the natspec comment for the `redeemCollateralForDsc` function:
   - Changed "depositing" to "withdrawing" to accurately reflect the function's purpose.

2. Fixed a small typo in the `burnDsc` function comment:
   - Changed "you DSC" to "your DSC".

3. Corrected another small typo in the `mintDsc` function comment:
   - Changed "hav" to "have".

These changes improve the clarity of the documentation, which will help us newer developers better understand the contract's functionality and reduce confusion.