### PR TITLE
Incorrect NetworkConfig parameters order for Anvil

### DIFF
--- a/script/HelperConfig.s.sol
+++ b/script/HelperConfig.s.sol
@@ -56,8 +56,8 @@ contract HelperConfig is Script {
 
         anvilNetworkConfig = NetworkConfig({
             wethUsdPriceFeed: address(ethUsdPriceFeed), // ETH / USD
-            weth: address(wethMock),
             wbtcUsdPriceFeed: address(btcUsdPriceFeed),
+            weth: address(wethMock),
             wbtc: address(wbtcMock),
             deployerKey: DEFAULT_ANVIL_PRIVATE_KEY
         });


### PR DESCRIPTION
Change order of parameters in the NetworkConfig returned in the getOrCreateAnvilEthConfig function. 
PR for the #109 issue.