### PR TITLE
DSCEngine.sol: Add a custom error  which is more clear, for burning amount exceeding current balance. 

### DIFF
--- a/src/DSCEngine.sol
+++ b/src/DSCEngine.sol
@@ -25,7 +25,7 @@
 pragma solidity 0.8.19;
 
 import { OracleLib, AggregatorV3Interface } from "./libraries/OracleLib.sol";
-// The correct path for ReentrancyGuard in latest Openzeppelin contracts is 
+// The correct path for ReentrancyGuard in latest Openzeppelin contracts is
 //"import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -62,6 +62,7 @@ contract DSCEngine is ReentrancyGuard {
     error DSCEngine__MintFailed();
     error DSCEngine__HealthFactorOk();
     error DSCEngine__HealthFactorNotImproved();
+    error DSCEngine__BurnAmountExceededBalance();
 
     ///////////////////
     // Types
@@ -306,6 +307,9 @@ contract DSCEngine is ReentrancyGuard {
     }
 
     function _burnDsc(uint256 amountDscToBurn, address onBehalfOf, address dscFrom) private {
+        if (i_dsc.balanceOf(dscFrom) < amountDscToBurn) {
+            revert DSCEngine__BurnAmountExceededBalance();
+        }
         s_DSCMinted[onBehalfOf] -= amountDscToBurn;
 
         bool success = i_dsc.transferFrom(dscFrom, address(this), amountDscToBurn);

--- a/test/unit/DSCEngineTest.t.sol
+++ b/test/unit/DSCEngineTest.t.sol
@@ -260,10 +260,19 @@ contract DSCEngineTest is StdCheats, Test {
         vm.stopPrank();
     }
 
-    function testCantBurnMoreThanUserHas() public {
+    function testCantBurnIfUserHasZeroBalance() public {
         vm.prank(user);
         vm.expectRevert();
         dsce.burnDsc(1);
+    }
+
+    function testCannotBurnMoreThanCurrentBalance() public depositedCollateralAndMintedDsc {
+        uint256 burnAmountMoreThanBalance = 101 ether;
+        vm.startPrank(user);
+        dsc.approve(address(dsce), burnAmountMoreThanBalance);
+        vm.expectRevert(DSCEngine.DSCEngine__BurnAmountExceededBalance.selector);
+        dsce.burnDsc(burnAmountMoreThanBalance);
+        vm.stopPrank();
     }
 
     function testCanBurnDsc() public depositedCollateralAndMintedDsc {


### PR DESCRIPTION
If user has minted a certain amount and the mapping `s_DSCMinted` is updated with that amount and tries to burn more than the current balance, the `s_DSCMinted[onBehalfOf] -= amountDscToBurn;` in `_burnDsc()` leads to arithmetic underflow as amount is uint256 type. The error returned is : `panic: arithmetic underflow or overflow (0x11)` which can be indeterminate. So I added the same check that exists in `DecentralizedStableCoin.sol` to check whether balance is more than burn amount before updating the mapping.  Also added a test for it and changed the name of the test which checks whether a user cannot burn if neither collateral is deposited nor coin is minted. 