### PR TITLE
Update DSCEngineTest.t.sol - testCanRedeemCollateral()

### DIFF
--- a/test/unit/DSCEngineTest.t.sol
+++ b/test/unit/DSCEngineTest.t.sol
@@ -315,11 +315,14 @@ contract DSCEngineTest is StdCheats, Test {
 
     function testCanRedeemCollateral() public depositedCollateral {
         vm.startPrank(user);
+        uint256 userBalanceBeforeRedeem = dsce.getCollateralBalanceOfUser(user, weth);
+        assertEq(userBalanceBeforeRedeem, amountCollateral);
         dsce.redeemCollateral(weth, amountCollateral);
-        uint256 userBalance = ERC20Mock(weth).balanceOf(user);
-        assertEq(userBalance, amountCollateral);
+        uint256 userBalanceAfterRedeem = dsce.getCollateralBalanceOfUser(user, weth);
+        assertEq(userBalanceAfterRedeem, 0);
         vm.stopPrank();
     }
+
 
     function testEmitCollateralRedeemedWithCorrectArgs() public depositedCollateral {
         vm.expectEmit(true, true, true, true, address(dsce));


### PR DESCRIPTION
in the previous testCanRedeemCollateral() function it was being asserted that userBalance = amountCollateral `assertEq(userBalance, amountCollateral)` but that test is bound to fail because the `user` only had `amountCollateral = 10 ether` deposited as collateral and after calling the `dsce.redeemCollateral(weth, amountCollateral);` LOC there's not going to be any collateral left in the DSCEngine. The modified test proves that `amountCollateral` was deposited and then redeemed.