### PR TITLE
🐞 fix(DSCEngineTest): fix `testRevertsIfTransferFromFails` function logic

### DIFF
--- a/test/unit/DSCEngineTest.t.sol
+++ b/test/unit/DSCEngineTest.t.sol
@@ -105,11 +105,13 @@ contract DSCEngineTest is StdCheats, Test {
     ///////////////////////////////////////
 
     function testRevertsIfTransferFromFails() public {
-        // In the foundry test, the default caller is msg.sender.We do not need to specify particularly.
+        address owner = msg.sender;
+        vm.prank(owner);
         MockFailedTransferFrom mockCollateralToken = new MockFailedTransferFrom();
         tokenAddresses = [address(mockCollateralToken)];
         feedAddresses = [ethUsdPriceFeed];
         // DSCEngine receives the third parameter as dscAddress, not the tokenAddress used as collateral.
+        vm.prank(owner);
         DSCEngine mockDsce = new DSCEngine(tokenAddresses, feedAddresses, address(dsc));
         mockCollateralToken.mint(user, amountCollateral);
         vm.startPrank(user);

--- a/test/unit/DSCEngineTest.t.sol
+++ b/test/unit/DSCEngineTest.t.sol
@@ -104,26 +104,19 @@ contract DSCEngineTest is StdCheats, Test {
     // depositCollateral Tests //
     ///////////////////////////////////////
 
-    // this test needs it's own setup
     function testRevertsIfTransferFromFails() public {
-        // Arrange - Setup
-        address owner = msg.sender;
-        vm.prank(owner);
-        MockFailedTransferFrom mockDsc = new MockFailedTransferFrom();
-        tokenAddresses = [address(mockDsc)];
+        // In the foundry test, the default caller is msg.sender.We do not need to specify particularly.
+        MockFailedTransferFrom mockCollateralToken = new MockFailedTransferFrom();
+        tokenAddresses = [address(mockCollateralToken)];
         feedAddresses = [ethUsdPriceFeed];
-        vm.prank(owner);
-        DSCEngine mockDsce = new DSCEngine(tokenAddresses, feedAddresses, address(mockDsc));
-        mockDsc.mint(user, amountCollateral);
-
-        vm.prank(owner);
-        mockDsc.transferOwnership(address(mockDsce));
-        // Arrange - User
+        // DSCEngine receives the third parameter as dscAddress, not the tokenAddress used as collateral.
+        DSCEngine mockDsce = new DSCEngine(tokenAddresses, feedAddresses, address(dsc));
+        mockCollateralToken.mint(user, amountCollateral);
         vm.startPrank(user);
-        ERC20Mock(address(mockDsc)).approve(address(mockDsce), amountCollateral);
+        ERC20Mock(address(mockCollateralToken)).approve(address(mockDsce), amountCollateral);
         // Act / Assert
         vm.expectRevert(DSCEngine.DSCEngine__TransferFailed.selector);
-        mockDsce.depositCollateral(address(mockDsc), amountCollateral);
+        mockDsce.depositCollateral(address(mockCollateralToken), amountCollateral);
         vm.stopPrank();
     }
 
@@ -322,7 +315,6 @@ contract DSCEngineTest is StdCheats, Test {
         assertEq(userBalanceAfterRedeem, 0);
         vm.stopPrank();
     }
-
 
     function testEmitCollateralRedeemedWithCorrectArgs() public depositedCollateral {
         vm.expectEmit(true, true, true, true, address(dsce));


### PR DESCRIPTION
Here's a clear explanation of the issue for my PR:

---

## Issue in `test_RevertIfTransferIsFailed` function

The current implementation of the `test_RevertIfTransferIsFailed` test has several unnecessary and potentially confusing elements:

1. **Incorrect DSC token parameter**: The test incorrectly passes the mock token (`mockCollateralToken`) as the third parameter to the `DSCEngine` constructor, which should actually be the DSC token address. This is confusing as it mixes the collateral token and the stablecoin token roles.

2. **Unnecessary ownership transfer**: The test transfers ownership of `mockCollateralToken` to the `mockDsce`. This step is unnecessary since we're only testing the `depositCollateral` function, which doesn't require any owner-only permissions on the token.

3. **Redundant address tracking**: The test uses an explicit `owner` variable and `vm.startPrank(owner)` when deploying contracts, but this is unnecessary as the default sender in tests is already the test contract itself.

## Proposed fix

The test can be simplified to focus clearly on its purpose - verifying that `DSCEngine` correctly handles a failed `transferFrom` operation during collateral deposit:

```solidity
    function testRevertsIfTransferFromFails() public {
        // In the foundry test, the default caller is msg.sender.We do not need to specify particularly.
        MockFailedTransferFrom mockCollateralToken = new MockFailedTransferFrom();
        tokenAddresses = [address(mockCollateralToken)];
        feedAddresses = [ethUsdPriceFeed];
        // DSCEngine receives the third parameter as dscAddress, not the tokenAddress used as collateral.
        DSCEngine mockDsce = new DSCEngine(tokenAddresses, feedAddresses, address(dsc));
        mockCollateralToken.mint(user, amountCollateral);
        vm.startPrank(user);
        ERC20Mock(address(mockCollateralToken)).approve(address(mockDsce), amountCollateral);
        // Act / Assert
        vm.expectRevert(DSCEngine.DSCEngine__TransferFailed.selector);
        mockDsce.depositCollateral(address(mockCollateralToken), amountCollateral);
        vm.stopPrank();
    }
```

This simplified version:
- Uses the correct DSC token parameter
- Eliminates the unnecessary ownership transfer
- Maintains the core test functionality to ensure that transfer failures are properly handled