### PR TITLE
 Refactor depositCollateral() to strictly follow CEI pattern

### DIFF
--- a/src/DSCEngine.sol
+++ b/src/DSCEngine.sol
@@ -278,12 +278,17 @@ contract DSCEngine is ReentrancyGuard {
         nonReentrant
         isAllowedToken(tokenCollateralAddress)
     {
+        // EFFECTS 
         s_collateralDeposited[msg.sender][tokenCollateralAddress] += amountCollateral;
-        emit CollateralDeposited(msg.sender, tokenCollateralAddress, amountCollateral);
+
+        // 3. INTERACTIONS
         bool success = IERC20(tokenCollateralAddress).transferFrom(msg.sender, address(this), amountCollateral);
         if (!success) {
             revert DSCEngine__TransferFailed();
         }
+        
+        // Emit after successful interaction
+        emit CollateralDeposited(msg.sender, tokenCollateralAddress, amountCollateral);
     }
 
     ///////////////////


### PR DESCRIPTION
In the original function, transferFrom() (an external interaction) occurs before any state effects. This violates CEI best practices and could be a potential reentrancy risk in edge cases. 

This PR reorders logic to:

Perform checks

Update internal state (s_collateralDeposits)

Then interact externally via transferFrom()

Finally, emit the event