### PR TITLE
Fix: Updated import paths

### DIFF
--- a/script/HelperConfig.s.sol
+++ b/script/HelperConfig.s.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.19;
 
 import { MockV3Aggregator } from "../test/mocks/MockV3Aggregator.sol";
 import { Script } from "forge-std/Script.sol";
-import { ERC20Mock } from "@openzeppelin/contracts/mocks/ERC20Mock.sol";
+import { ERC20Mock } from "../test/mocks/ERC20Mock.sol";
 
 contract HelperConfig is Script {
     NetworkConfig public activeNetworkConfig;

--- a/test/fuzz/continueOnRevert/ContinueOnRevertHandler.t.sol
+++ b/test/fuzz/continueOnRevert/ContinueOnRevertHandler.t.sol
@@ -14,7 +14,6 @@ import { DSCEngine, AggregatorV3Interface } from "../../../src/DSCEngine.sol";
 import { DecentralizedStableCoin } from "../../../src/DecentralizedStableCoin.sol";
 // import {Randomish, EnumerableSet} from "../Randomish.sol"; // Randomish is not found in the codebase, EnumerableSet
 // is imported from openzeppelin
-import { MockV3Aggregator } from "../../mocks/MockV3Aggregator.sol";
 import { console } from "forge-std/console.sol";
 
 contract ContinueOnRevertHandler is Test {


### PR DESCRIPTION
Here, I made two changes in this PR:

1. In `script/HelperConfig.s.sol`, on line 6, I changed `import { ERC20Mock } from "@openzeppelin/contracts/mocks/ERC20Mock.sol";` to `import { ERC20Mock } from "../test/mocks/ERC20Mock.sol";`. This change will be discussed soon.
2. In `test/fuzz/continueOnRevert/ContinueOnRevertHandler.t.sol`, I removed a duplicate import of `MockV3Aggregator`, which can be seen in the attached image (Lines 12 and 17).

![image_2025-07-03_112543782](https://github.com/user-attachments/assets/51397899-8ccc-4ee4-8115-d689a9e0f162)

Regarding `ERC20Mock`: this change does not fix any issues, but it remains necessary because of the convention we follow. Throughout the entire codebase, we have used the `ERC20Mock` located in our `test/mocks/` directory (see line 9 in the above image). This is likely to prevent problems if someone upgrades the `openzeppelin-contracts` version or installs the latest one. 

In such cases, the code could break because OpenZeppelin has moved the location of the `ERC20Mock` contract altogether. Therefore, the best bet is to continue using the `ERC20Mock` contract declared in our test directory.