### PR TITLE
Refactor test for zero collateral deposit

### DIFF
--- a/test/unit/DSCEngineTest.t.sol
+++ b/test/unit/DSCEngineTest.t.sol
@@ -123,12 +123,8 @@ contract DSCEngineTest is StdCheats, Test {
     }
 
     function testRevertsIfCollateralZero() public {
-        vm.startPrank(user);
-        ERC20Mock(weth).approve(address(dsce), amountCollateral);
-
         vm.expectRevert(DSCEngine.DSCEngine__NeedsMoreThanZero.selector);
         dsce.depositCollateral(weth, 0);
-        vm.stopPrank();
     }
 
     function testRevertsWithUnapprovedCollateral() public {


### PR DESCRIPTION
Removed unnecessary approval step before testing collateral deposit.

Since amountCollateral = 0, the moreThanZero modifier fails immediately, so:

- The function never reaches the transferFrom() call
- No token approval is needed because the transfer never happens
- The revert occurs at the modifier level